### PR TITLE
feat: add workflows for linting and building/releasing iso

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -1,0 +1,45 @@
+---
+name: Build ArchLinux zfs iso
+on:
+  schedule:  # arch relases are published first day of the month
+    - cron: '50 23 1 * *'  # https://gitlab.archlinux.org/archlinux/releng/-/pipeline_schedules
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  iso:
+    if: ${{ github.event.pull_request.merged == true ||
+         github.event_name == 'schedule' ||
+         github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+      options: --privileged
+    steps:
+      - name: Set timestamp tag
+        id: timetag
+        run: echo "timestamp=$(date +'%Y%m%d')" >> "$GITHUB_ENV"
+      - name: Check out codebase
+        uses: actions/checkout@v3
+      - name: Install requirements
+        run: |
+          pacman -Sy
+          pacman -S --noconfirm archlinux-keyring archiso
+          pacman-key --init
+          pacman-key -r DDF7DB817396A49B2A2723F7403BD972F75D9D76
+          pacman-key --lsign-key DDF7DB817396A49B2A2723F7403BD972F75D9D76
+      - name: Build iso
+        run: |
+          chmod +x ./*.sh
+          ls
+          bash ./build.sh -r week --verbose
+      - name: Upload a release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: archlinux-archzfs-linux-${{ env.timestamp }}
+          tag_name: ${{ env.timestamp }}
+          prerelease: ${{ github.event_name != 'schedule' }}
+          files: |
+            dynamic_data/out/*

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,55 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    branches-ignore: [master, main]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master, main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Adds workflow for linting code
  * Runs when : 
    * Pushing
    * Pull requests created for master branch
* Adds workflow for building the iso and uploading it to github releases
  * Runs when:
    * On the end of the first date of every month, since archlinux releases are made on schedule the first date of month.
      * see:  https://gitlab.archlinux.org/archlinux/releng/-/pipeline_schedules 
      * uploads the iso as a new release in this repo.
    * On every pull request that's merged.
      * uploads the iso as a new prerelease in this repo.

Fixes #5 