### PR TITLE
fix dependency issue

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install requirements
         run: |
           pacman -Sy
-          pacman -S --noconfirm archlinux-keyring archiso
+          pacman -S --noconfirm archlinux-keyring archiso git
           pacman-key --init
           pacman-key -r DDF7DB817396A49B2A2723F7403BD972F75D9D76
           pacman-key --lsign-key DDF7DB817396A49B2A2723F7403BD972F75D9D76

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -7,12 +7,14 @@ on:
   pull_request:
     types:
       - closed
+  push:
 
 jobs:
   iso:
     if: ${{ github.event.pull_request.merged == true ||
          github.event_name == 'schedule' ||
-         github.event_name == 'workflow_dispatch' }}
+         github.event_name == 'workflow_dispatch' ||
+         github.event.repository.default_branch }}
     runs-on: ubuntu-latest
     container:
       image: archlinux:latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,8 +16,6 @@ name: Lint Code Base
 #############################
 on:
   push:
-    branches-ignore: [master, main]
-    # Remove the line above to run when pushing to master
   pull_request:
     branches: [master, main]
 


### PR DESCRIPTION
Workflow was broken since https://github.com/stevleibelt/arch-linux-live-cd-iso-with-zfs/commit/6c90c9039b0ec0a7f7f40f550c40d669d2cf90a6 introduced git as a dependency.

Also made changes to run the build workflow on push to `master`, so that it will be immediately clear if changes break the workflow.